### PR TITLE
Fix SS58Prefix

### DIFF
--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -162,7 +162,7 @@ type MoreThanHalfCouncil = EitherOfDiverse<
 
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
-	pub const SS58Prefix: u8 = 0;
+	pub const SS58Prefix: u8 = 42;
 }
 
 impl frame_system::Config for Runtime {


### PR DESCRIPTION
We can't change SS58Prefix from chainspec, it should be defined on runtime.