### PR TITLE
Release runtime v94000004 (re-release with WASM CI)

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -93,3 +93,31 @@ jobs:
             ./scripts/ci/dockerfiles/polkadot/docker-bake.hcl
             ${{ steps.meta.outputs.bake-file }}
           targets: rootchain
+
+      - name: Extract runtime WASM artifacts
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/bake-action@v5
+        with:
+          pull: false
+          push: false
+          set: |
+            wasm-artifacts.args.AWS_ACCESS_KEY_ID=${{ env.MINIO_ACCESS_KEY_ID }}
+            wasm-artifacts.args.AWS_SECRET_ACCESS_KEY=${{ env.MINIO_SECRET_ACCESS_KEY }}
+            wasm-artifacts.args.SCCACHE_BUCKET=${{ env.SCCACHE_BUCKET }}
+            wasm-artifacts.args.SCCACHE_ENDPOINT=${{ env.SCCACHE_ENDPOINT }}
+            wasm-artifacts.args.SCCACHE_S3_USE_SSL=true
+            wasm-artifacts.args.SCCACHE_REGION=${{ env.SCCACHE_REGION }}
+          files: |
+            ./scripts/ci/dockerfiles/polkadot/docker-bake.hcl
+          targets: wasm-artifacts
+
+      - name: Upload WASM artifacts to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ls -lh ./artifacts/*.wasm
+          gh release upload "${{ github.ref_name }}" \
+            ./artifacts/thxnet_runtime.compact.compressed.wasm \
+            ./artifacts/thxnet_testnet_runtime.compact.compressed.wasm \
+            --clobber

--- a/scripts/ci/dockerfiles/polkadot/docker-bake.hcl
+++ b/scripts/ci/dockerfiles/polkadot/docker-bake.hcl
@@ -12,6 +12,13 @@ group "default" {
   ]
 }
 
+group "all" {
+  targets = [
+    "rootchain",
+    "wasm-artifacts",
+  ]
+}
+
 target "rootchain" {
   dockerfile = "scripts/ci/dockerfiles/polkadot/polkadot_builder.Dockerfile"
   target     = "rootchain"
@@ -37,5 +44,25 @@ target "rootchain" {
     sccache         = "docker-image://ghcr.io/thxnet/ci-containers/sccache:0.14.0"
     substrate-based = "docker-image://ghcr.io/thxnet/ci-containers/substrate-based:build-2023.05.20-41956af"
     ubuntu          = "docker-image://docker.io/library/ubuntu:22.04"
+  }
+}
+
+target "wasm-artifacts" {
+  dockerfile = "scripts/ci/dockerfiles/polkadot/polkadot_builder.Dockerfile"
+  target     = "wasm-artifacts"
+  platforms  = ["linux/amd64"]
+  output     = ["type=local,dest=./artifacts"]
+  args = {
+    RUSTC_WRAPPER         = "/usr/bin/sccache"
+    AWS_ACCESS_KEY_ID     = null
+    AWS_SECRET_ACCESS_KEY = null
+    SCCACHE_BUCKET        = null
+    SCCACHE_ENDPOINT      = null
+    SCCACHE_S3_USE_SSL    = null
+    SCCACHE_REGION        = null
+  }
+  contexts = {
+    sccache         = "docker-image://ghcr.io/thxnet/ci-containers/sccache:0.14.0"
+    substrate-based = "docker-image://ghcr.io/thxnet/ci-containers/substrate-based:build-2023.05.20-41956af"
   }
 }

--- a/scripts/ci/dockerfiles/polkadot/polkadot_builder.Dockerfile
+++ b/scripts/ci/dockerfiles/polkadot/polkadot_builder.Dockerfile
@@ -20,6 +20,11 @@ ARG SCCACHE_REGION
 
 RUN cargo build --locked --release && sccache --show-stats
 
+# Stage: export compact compressed WASM runtime artifacts
+FROM scratch as wasm-artifacts
+COPY --from=builder /build/target/release/wbuild/thxnet-runtime/thxnet_runtime.compact.compressed.wasm /
+COPY --from=builder /build/target/release/wbuild/thxnet-testnet-runtime/thxnet_testnet_runtime.compact.compressed.wasm /
+
 # This is the 2nd stage: a very small image where we copy the THXENT. binary."
 FROM ubuntu as rootchain
 


### PR DESCRIPTION
## Summary

- Re-release of runtime 94000004 with WASM artifact CI pipeline changes
- Adds `wasm-artifacts` Docker build stage to extract runtime WASM blobs
- Adds GitHub Actions steps to upload WASM artifacts to GitHub Releases on tag pushes

## Changes since previous release

- Add WASM artifact extraction and upload to CI pipeline (`1db83e434`)

## Previous release changes (carried over)

- ParachainHost v4 API for thxnet runtimes
- CI Docker fix for buildx >= 0.20.0
- GRANDPA finality deadlock fix migration
- Node binary hotfix (LongestChain for SelectRelayChain)
- sccache with Minio S3 backend
- Postmortem & runtime upgrade tooling

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, tag push triggers WASM extraction + upload
- [ ] Release page shows 2 WASM files attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)