### PR TITLE
Release runtime v94000005

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5517,6 +5517,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-finality-rescue"
+version = "4.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-grandpa",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#ba87188cce8c0a11c9542d7363cd5ddd46db2740"
@@ -12105,6 +12122,7 @@ dependencies = [
  "pallet-election-provider-support-benchmarking",
  "pallet-elections-phragmen",
  "pallet-fast-unstake",
+ "pallet-finality-rescue",
  "pallet-grandpa",
  "pallet-identity",
  "pallet-im-online",
@@ -12223,6 +12241,7 @@ dependencies = [
  "pallet-election-provider-support-benchmarking",
  "pallet-elections-phragmen",
  "pallet-fast-unstake",
+ "pallet-finality-rescue",
  "pallet-grandpa",
  "pallet-identity",
  "pallet-im-online",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ members = [
     "node/zombienet-backchannel",
     "rpc",
     "pallets/dao",
+    "pallets/finality-rescue",
     "parachain",
     "parachain/test-parachains",
     "parachain/test-parachains/adder",

--- a/pallets/finality-rescue/Cargo.toml
+++ b/pallets/finality-rescue/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "pallet-finality-rescue"
+version = "4.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://substrate.io"
+repository = "https://github.com/paritytech/substrate/"
+description = "FRAME pallet for emergency GRANDPA finality rescue"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
+log = { version = "0.4.17", default-features = false }
+scale-info = { version = "2.5.0", default-features = false, features = [
+    "derive",
+] }
+
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+
+pallet-grandpa = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+
+[dev-dependencies]
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "pallet-grandpa/std",
+    "scale-info/std",
+    "sp-runtime/std",
+    "sp-std/std",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/finality-rescue/src/lib.rs
+++ b/pallets/finality-rescue/src/lib.rs
@@ -1,0 +1,154 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::{pallet_prelude::*, storage};
+	use frame_system::pallet_prelude::*;
+	use sp_runtime::traits::Zero;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config + pallet_grandpa::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// Minimum number of blocks between rescue calls.
+		#[pallet::constant]
+		type RescueCooldown: Get<Self::BlockNumber>;
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn last_rescue_block)]
+	pub type LastRescueBlock<T: Config> = StorageValue<_, T::BlockNumber>;
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Finality rescue executed successfully.
+		FinalityRescueExecuted {
+			block_number: T::BlockNumber,
+			median: T::BlockNumber,
+			authority_count: u32,
+			old_set_id: u64,
+			new_set_id: u64,
+		},
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Cooldown period has not elapsed since last rescue.
+		CooldownNotElapsed,
+		/// No GRANDPA authorities found.
+		NoAuthorities,
+		/// Failed to schedule authority change.
+		ScheduleChangeFailed,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Emergency rescue of GRANDPA finality.
+		///
+		/// Clears stale GRANDPA state (PendingChange, NextForced, Stalled),
+		/// schedules a forced authority change with the current authorities,
+		/// and increments CurrentSetId.
+		///
+		/// `median` must be the last finalized block number, obtained from
+		/// `chain_getFinalizedHead` RPC.
+		///
+		/// Can only be called by root (via sudo).
+		#[pallet::call_index(0)]
+		#[pallet::weight(T::DbWeight::get().reads_writes(5, 6))]
+		pub fn rescue_finality(
+			origin: OriginFor<T>,
+			median: T::BlockNumber,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+
+			let block_number = <frame_system::Pallet<T>>::block_number();
+
+			// Cooldown check
+			if let Some(last) = LastRescueBlock::<T>::get() {
+				ensure!(
+					block_number >= last + T::RescueCooldown::get(),
+					Error::<T>::CooldownNotElapsed
+				);
+			}
+
+			// Storage key prefixes for GRANDPA internal state
+			let current_set_id_key = storage::storage_prefix(b"Grandpa", b"CurrentSetId");
+			let pending_change_key = storage::storage_prefix(b"Grandpa", b"PendingChange");
+			let next_forced_key = storage::storage_prefix(b"Grandpa", b"NextForced");
+			let stalled_key = storage::storage_prefix(b"Grandpa", b"Stalled");
+
+			// Step 1: Clear all stale GRANDPA state
+			if storage::unhashed::exists(&pending_change_key) {
+				log::info!(
+					target: "runtime::finality-rescue",
+					"Clearing stale PendingChange",
+				);
+			}
+			storage::unhashed::kill(&pending_change_key);
+			storage::unhashed::kill(&next_forced_key);
+			storage::unhashed::kill(&stalled_key);
+
+			// Step 2: Get current authorities
+			let authorities = pallet_grandpa::Pallet::<T>::grandpa_authorities();
+			ensure!(!authorities.is_empty(), Error::<T>::NoAuthorities);
+			let authority_count = authorities.len() as u32;
+
+			// Step 3: Schedule forced authority change
+			// With delay=0, on_finalize in the same block will:
+			//   1. Emit ForcedChange(median, ScheduledChange) consensus log
+			//   2. Apply the change (set_grandpa_authorities + kill PendingChange)
+			pallet_grandpa::Pallet::<T>::schedule_change(authorities, Zero::zero(), Some(median))
+				.map_err(|e| {
+					log::error!(
+						target: "runtime::finality-rescue",
+						"schedule_change failed: {:?}",
+						e,
+					);
+					Error::<T>::ScheduleChangeFailed
+				})?;
+
+			// Step 4: Increment CurrentSetId
+			// on_finalize does NOT increment CurrentSetId for forced changes,
+			// but the GRANDPA client does: new_set_id = self.set_id + 1
+			let old_set_id: u64 = storage::unhashed::get_or_default(&current_set_id_key);
+			let new_set_id: u64 = old_set_id + 1;
+			storage::unhashed::put(&current_set_id_key, &new_set_id);
+
+			// Step 5: Record and emit
+			LastRescueBlock::<T>::put(block_number);
+
+			log::info!(
+				target: "runtime::finality-rescue",
+				"Finality rescue applied at block #{:?}: ForcedChange(median={:?}) \
+				 scheduled with {} authorities, CurrentSetId {} -> {}",
+				block_number,
+				median,
+				authority_count,
+				old_set_id,
+				new_set_id,
+			);
+
+			Self::deposit_event(Event::FinalityRescueExecuted {
+				block_number,
+				median,
+				authority_count,
+				old_set_id,
+				new_set_id,
+			});
+
+			// Emergency operation - no fee
+			Ok(Pays::No.into())
+		}
+	}
+}

--- a/pallets/finality-rescue/src/mock.rs
+++ b/pallets/finality-rescue/src/mock.rs
@@ -1,0 +1,94 @@
+use frame_support::{construct_runtime, parameter_types, traits::{ConstU32, ConstU64}};
+use sp_core::H256;
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system,
+		Grandpa: pallet_grandpa,
+		FinalityRescue: crate,
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const RescueCooldown: u64 = 10;
+}
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+
+impl pallet_grandpa::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type MaxAuthorities = ConstU32<100>;
+	type MaxSetIdSessionEntries = ConstU64<0>;
+	type KeyOwnerProof = sp_core::Void;
+	type EquivocationReportSystem = ();
+}
+
+impl crate::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type RescueCooldown = RescueCooldown;
+}
+
+pub fn test_authorities() -> Vec<(pallet_grandpa::AuthorityId, u64)> {
+	use sp_core::crypto::UncheckedFrom;
+	vec![
+		(pallet_grandpa::AuthorityId::unchecked_from([1u8; 32]), 1),
+		(pallet_grandpa::AuthorityId::unchecked_from([2u8; 32]), 1),
+		(pallet_grandpa::AuthorityId::unchecked_from([3u8; 32]), 1),
+	]
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	use frame_support::traits::GenesisBuild;
+
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+
+	<pallet_grandpa::GenesisConfig as GenesisBuild<Test>>::assimilate_storage(
+		&pallet_grandpa::GenesisConfig { authorities: test_authorities() },
+		&mut t,
+	)
+	.unwrap();
+
+	t.into()
+}
+
+pub fn new_test_ext_no_authorities() -> sp_io::TestExternalities {
+	frame_system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+}

--- a/pallets/finality-rescue/src/tests.rs
+++ b/pallets/finality-rescue/src/tests.rs
@@ -1,0 +1,117 @@
+use crate::mock::*;
+use frame_support::{assert_noop, assert_ok, storage, traits::Hooks};
+
+#[test]
+fn rescue_finality_works() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		// Seed stale PendingChange to simulate deadlock
+		let pending_change_key = storage::storage_prefix(b"Grandpa", b"PendingChange");
+		storage::unhashed::put_raw(&pending_change_key, &[1, 2, 3]);
+
+		let median = 0u64;
+		assert_ok!(FinalityRescue::rescue_finality(RuntimeOrigin::root(), median));
+
+		// Verify event was emitted
+		let events = System::events();
+		assert!(events.iter().any(|e| matches!(
+			e.event,
+			RuntimeEvent::FinalityRescue(crate::Event::FinalityRescueExecuted {
+				block_number: 1,
+				median: 0,
+				authority_count: 3,
+				old_set_id: 0,
+				new_set_id: 1,
+			})
+		)));
+
+		// Verify CurrentSetId was incremented
+		let current_set_id_key = storage::storage_prefix(b"Grandpa", b"CurrentSetId");
+		let set_id: u64 = storage::unhashed::get_or_default(&current_set_id_key);
+		assert_eq!(set_id, 1);
+
+		// Verify LastRescueBlock was set
+		assert_eq!(FinalityRescue::last_rescue_block(), Some(1));
+	});
+}
+
+#[test]
+fn rescue_finality_requires_root() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			FinalityRescue::rescue_finality(RuntimeOrigin::signed(1), 0),
+			frame_support::error::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn rescue_finality_cooldown_enforced() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		assert_ok!(FinalityRescue::rescue_finality(RuntimeOrigin::root(), 0));
+
+		// Try again at block 5 (within cooldown of 10)
+		System::set_block_number(5);
+		assert_noop!(
+			FinalityRescue::rescue_finality(RuntimeOrigin::root(), 0),
+			crate::Error::<Test>::CooldownNotElapsed
+		);
+
+		// Should work at block 11 (cooldown elapsed)
+		System::set_block_number(11);
+		assert_ok!(FinalityRescue::rescue_finality(RuntimeOrigin::root(), 0));
+
+		// Verify set_id incremented again
+		let current_set_id_key = storage::storage_prefix(b"Grandpa", b"CurrentSetId");
+		let set_id: u64 = storage::unhashed::get_or_default(&current_set_id_key);
+		assert_eq!(set_id, 2);
+	});
+}
+
+#[test]
+fn rescue_finality_fails_without_authorities() {
+	new_test_ext_no_authorities().execute_with(|| {
+		System::set_block_number(1);
+		assert_noop!(
+			FinalityRescue::rescue_finality(RuntimeOrigin::root(), 0),
+			crate::Error::<Test>::NoAuthorities
+		);
+	});
+}
+
+#[test]
+fn rescue_finality_works_without_stale_state() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		// No stale state seeded - should still work (kill on non-existent key is no-op)
+		assert_ok!(FinalityRescue::rescue_finality(RuntimeOrigin::root(), 0));
+
+		// Verify it worked
+		assert_eq!(FinalityRescue::last_rescue_block(), Some(1));
+	});
+}
+
+#[test]
+fn rescue_finality_on_finalize_applies_change() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		assert_ok!(FinalityRescue::rescue_finality(RuntimeOrigin::root(), 0));
+
+		// PendingChange should be set by schedule_change
+		let pending_change_key = storage::storage_prefix(b"Grandpa", b"PendingChange");
+		assert!(storage::unhashed::exists(&pending_change_key));
+
+		// Run on_finalize for Grandpa — this processes the pending change
+		Grandpa::on_finalize(1);
+
+		// PendingChange should be cleared after on_finalize (delay=0 means same block)
+		assert!(!storage::unhashed::exists(&pending_change_key));
+
+		// Authorities should still be the same (we scheduled the same set)
+		let authorities = pallet_grandpa::Pallet::<Test>::grandpa_authorities();
+		assert_eq!(authorities.len(), 3);
+	});
+}

--- a/runtime/thxnet-testnet/Cargo.toml
+++ b/runtime/thxnet-testnet/Cargo.toml
@@ -51,6 +51,7 @@ pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", 
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-dao = { path = "../../pallets/dao", default-features = false }
+pallet-finality-rescue = { path = "../../pallets/finality-rescue", default-features = false }
 pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-election-provider-multi-phase = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
@@ -201,6 +202,7 @@ std = [
     "pallet-assets/std",
     "pallet-nfts/std",
     "pallet-nfts-runtime-api/std",
+    "pallet-finality-rescue/std",
 ]
 runtime-benchmarks = [
     "runtime-common/runtime-benchmarks",
@@ -288,6 +290,7 @@ try-runtime = [
     "pallet-assets/try-runtime",
     "pallet-asset-tx-payment/try-runtime",
     "pallet-nfts/try-runtime",
+    "pallet-finality-rescue/try-runtime",
 ]
 # When enabled, the runtime API will not be build.
 #

--- a/runtime/thxnet-testnet/src/lib.rs
+++ b/runtime/thxnet-testnet/src/lib.rs
@@ -136,7 +136,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("thxnet"),
 	impl_name: create_runtime_str!("thxlab"),
 	authoring_version: 0,
-	spec_version: 94000004,
+	spec_version: 94000005,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
@@ -1214,6 +1214,16 @@ impl pallet_dao::Config for Runtime {
 }
 
 parameter_types! {
+	/// Minimum blocks between rescue_finality calls (~10 min at 6s/block).
+	pub const RescueCooldown: BlockNumber = 100;
+}
+
+impl pallet_finality_rescue::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type RescueCooldown = RescueCooldown;
+}
+
+parameter_types! {
 	// One storage item; key size 32, value size 8; .
 	pub const ProxyDepositBase: Balance = deposit(1, 8);
 	// Additional storage item size of 33 bytes.
@@ -1620,6 +1630,7 @@ construct_runtime! {
 		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 132,
 		Nfts: pallet_nfts::{Pallet, Call, Storage, Event<T>} = 133,
 		Dao: pallet_dao::{Pallet, Call, Storage, Event<T>}  = 134,
+		FinalityRescue: pallet_finality_rescue::{Pallet, Call, Storage, Event<T>} = 135,
 
 		// Consensus support.
 		// Authorship must be before session in order to note author in the correct session and era

--- a/runtime/thxnet/Cargo.toml
+++ b/runtime/thxnet/Cargo.toml
@@ -52,6 +52,7 @@ pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/parityt
 pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-dao = { path = "../../pallets/dao", default-features = false }
+pallet-finality-rescue = { path = "../../pallets/finality-rescue", default-features = false }
 pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-election-provider-multi-phase = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-fast-unstake = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
@@ -201,6 +202,7 @@ std = [
     "pallet-assets/std",
     "pallet-nfts/std",
     "pallet-nfts-runtime-api/std",
+    "pallet-finality-rescue/std",
 ]
 runtime-benchmarks = [
     "runtime-common/runtime-benchmarks",
@@ -288,6 +290,7 @@ try-runtime = [
     "pallet-assets/try-runtime",
     "pallet-asset-tx-payment/try-runtime",
     "pallet-nfts/try-runtime",
+    "pallet-finality-rescue/try-runtime",
 ]
 # When enabled, the runtime API will not be build.
 #

--- a/runtime/thxnet/src/lib.rs
+++ b/runtime/thxnet/src/lib.rs
@@ -136,7 +136,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("thxnet"),
 	impl_name: create_runtime_str!("thxlab"),
 	authoring_version: 0,
-	spec_version: 94000004,
+	spec_version: 94000005,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
@@ -1184,6 +1184,16 @@ impl pallet_dao::Config for Runtime {
 	type Vote = u128;
 }
 
+parameter_types! {
+	/// Minimum blocks between rescue_finality calls (~10 min at 6s/block).
+	pub const RescueCooldown: BlockNumber = 100;
+}
+
+impl pallet_finality_rescue::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type RescueCooldown = RescueCooldown;
+}
+
 impl pallet_nfts::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type CollectionId = u32;
@@ -1620,6 +1630,7 @@ construct_runtime! {
 		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 132,
 		Nfts: pallet_nfts::{Pallet, Call, Storage, Event<T>} = 133,
 		Dao: pallet_dao::{Pallet, Call, Storage, Event<T>}  = 134,
+		FinalityRescue: pallet_finality_rescue::{Pallet, Call, Storage, Event<T>} = 135,
 
 		// Consensus support.
 		// Authorship must be before session in order to note author in the correct session and era


### PR DESCRIPTION
## Summary

- Add **pallet-finality-rescue** for emergency GRANDPA finality recovery
- Bump `spec_version` from 94000004 to 94000005
- Includes all v94000004 hotfix commits previously on `develop`

## Changelog

### New: pallet-finality-rescue
- Sudo-callable `rescue_finality(median)` dispatchable
- Clears stale GRANDPA state and schedules forced authority change
- Cooldown mechanism (100 blocks ≈ 10 min) to prevent abuse
- Integrated into both thxnet and thxnet-testnet runtimes (index=135)
- 7 unit tests passing

### Infrastructure (from v94000004 cycle)
- WASM artifact extraction and upload in CI pipeline
- Postmortem doc and runtime upgrade tooling for v94000004
- sccache with Minio S3 backend for CI builds
- LongestChain fix for SelectRelayChain (finality deadlock Layer 2)
- GRANDPA finality deadlock fix migration for runtime v94000004
- GitHub Actions Docker actions upgrade
- ParachainHost v4 API for thxnet runtimes

## Test plan

- [x] `cargo test -p pallet-finality-rescue` — 7/7 tests pass
- [ ] CI builds WASM artifacts on tag push
- [ ] Runtime upgrade tested on testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)