### PR TITLE
ci: align all workflows to ARC scale sets (hetzner-thxnet / hetzner-thxnet-light)

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   image:
     name: Build and publish images
-    runs-on: [self-hosted, hetzner-thxnet]
+    runs-on: hetzner-thxnet
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Normalize runs-on on the default branch to the canonical ARC scale-set scalar form, so GitHub Actions jobs reliably land on hetzner-thxnet / hetzner-thxnet-light autoscaling runner sets managed by gha-runner-scale-set on our k3d cluster. The broker routes by scale-set name; array forms like [self-hosted, hetzner-thxnet] work today but the self-hosted token is a no-op.

## Change table

| file:line | old | new |
|---|---|---|
| .github/workflows/integration.yaml:38 | [self-hosted, hetzner-thxnet] | hetzner-thxnet |

## Verified sweep after change

.github/workflows/integration.yaml:38:    runs-on: hetzner-thxnet

## Out-of-scope notes

- feature/fork-genesis-cli already scalar — no change required.
- fix/session-info-zero-thxnet-cascade still has runs-on: [hetzner] at integration.yaml:34. Recommend rebase onto main once this merges.

THXLAB AI Team